### PR TITLE
feat: Introducing send_tx rpc api

### DIFF
--- a/near-accounts/examples/async_tx.rs
+++ b/near-accounts/examples/async_tx.rs
@@ -78,8 +78,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(err) => println!("Error: {:#?}", err),
     }
-    
-    println!("Time taken for aysnc request: {:?}",t2-t1);
-    println!("Time taken for status request: {:?}",t4-t3);
+
+    println!("Time taken for aysnc request: {:?}", t2 - t1);
+    println!("Time taken for status request: {:?}", t4 - t3);
     Ok(())
 }

--- a/near-accounts/examples/async_tx.rs
+++ b/near-accounts/examples/async_tx.rs
@@ -1,0 +1,90 @@
+//! This example uses the transact_advance method to send  transaction and check its status
+use near_accounts::Account;
+use near_crypto::{InMemorySigner, SecretKey};
+use near_primitives::views::TxExecutionStatus;
+use near_primitives::{types::Gas, views::FinalExecutionOutcomeViewEnum};
+use near_providers::jsonrpc_primitives::types::transactions::{
+    RpcTransactionError, TransactionInfo,
+};
+use near_providers::JsonRpcProvider;
+use near_providers::Provider;
+use std::sync::Arc;
+mod utils;
+use near_primitives::types::AccountId;
+use serde_json::json;
+use tokio::time;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let signer_account_id: AccountId = "near-api-rs.testnet".parse::<AccountId>()?;
+    let signer_secret_key = "ed25519:29nYmQCZMsQeYtztXZzm57ayQt2uBHXdn2SAjK4ccMGSQaNUFNJ7Aoteno81eKTex9cGBbk1FuDuqJRsdzx34xDY".parse::<SecretKey>()?;
+    let contract_id: AccountId = "contract.near-api-rs.testnet".parse::<AccountId>()?;
+    let signer = InMemorySigner::from_secret_key(signer_account_id.clone(), signer_secret_key);
+
+    let gas: Gas = 100_000_000_000_000; // Example amount in yoctoNEAR
+
+    let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
+    let signer = Arc::new(signer);
+
+    let account = Account::new(signer_account_id, signer, provider.clone());
+    let method_name = "set_status".to_string();
+
+    let args_json = json!({"message": "working1"});
+
+    let transaction_sender = account
+        .function_call(&contract_id, method_name, args_json, gas, 0)
+        .await?;
+
+    let tx_hash = transaction_sender.clone().get_transaction_hash().unwrap();
+
+    let t1 = time::Instant::now();
+    //Different Wait_until values:  None, Included, ExecutedOptimistic, IncludedFinal, Executed, Final
+    let result = transaction_sender.transact_advanced("NONE").await;
+    let t2 = time::Instant::now();
+    // match result {
+    //     Ok(res) => match &res.final_execution_outcome {
+    //         //Final Execution outcome for finality NONE would always be empty.
+    //         Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(outcome)) => {
+    //             println!("Final Exuecution outcome: {:?}", outcome);
+    //             println!("Final Exuecution outcome: {:?}", outcome.transaction);
+    //         }
+    //         Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
+    //             outcome_receipt,
+    //         )) => {
+    //             println!("Final Exuecution outcome: {:?}", outcome_receipt)
+    //         }
+    //         None => println!("No Final execution outcome."),
+    //     },
+    //     Err(err) => println!("Error: {:#?}", err),
+    // }
+
+    //Check the status of the transaction now.
+    let transaction_info = TransactionInfo::TransactionId {
+        tx_hash,
+        sender_account_id: account.account_id,
+    };
+    let wait_until = TxExecutionStatus::ExecutedOptimistic;
+
+    time::sleep(time::Duration::from_secs(5)).await;
+
+    let t3 = time::Instant::now();
+    let tx_status = provider.tx_status(transaction_info, wait_until).await;
+    let t4 = time::Instant::now();
+
+    match tx_status {
+        Ok(response) => {
+            //println!("response gotten after: {}s", delta);
+            println!("response: {:#?}", response);
+        }
+        Err(err) => println!("Error: {:#?}", err),
+    }
+    
+    println!("Time taken for aysnc request: {:?}",t2-t1);
+    println!("Time taken for status request: {:?}",t4-t3);
+
+    println!("Time taken for two requests: {:?}",(t4-t3)+(t2-t1));
+
+    Ok(())
+}

--- a/near-accounts/examples/async_tx.rs
+++ b/near-accounts/examples/async_tx.rs
@@ -3,9 +3,7 @@ use near_accounts::Account;
 use near_crypto::{InMemorySigner, SecretKey};
 use near_primitives::views::TxExecutionStatus;
 use near_primitives::{types::Gas, views::FinalExecutionOutcomeViewEnum};
-use near_providers::jsonrpc_primitives::types::transactions::{
-    RpcTransactionError, TransactionInfo,
-};
+use near_providers::jsonrpc_primitives::types::transactions::TransactionInfo;
 use near_providers::JsonRpcProvider;
 use near_providers::Provider;
 use std::sync::Arc;
@@ -43,22 +41,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //Different Wait_until values:  None, Included, ExecutedOptimistic, IncludedFinal, Executed, Final
     let result = transaction_sender.transact_advanced("NONE").await;
     let t2 = time::Instant::now();
-    // match result {
-    //     Ok(res) => match &res.final_execution_outcome {
-    //         //Final Execution outcome for finality NONE would always be empty.
-    //         Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(outcome)) => {
-    //             println!("Final Exuecution outcome: {:?}", outcome);
-    //             println!("Final Exuecution outcome: {:?}", outcome.transaction);
-    //         }
-    //         Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
-    //             outcome_receipt,
-    //         )) => {
-    //             println!("Final Exuecution outcome: {:?}", outcome_receipt)
-    //         }
-    //         None => println!("No Final execution outcome."),
-    //     },
-    //     Err(err) => println!("Error: {:#?}", err),
-    // }
+    match result {
+        Ok(res) => match &res.final_execution_outcome {
+            //Final Execution outcome for finality NONE would always be empty.
+            Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(outcome)) => {
+                println!("Final Exuecution outcome: {:?}", outcome);
+                println!("Final Exuecution outcome: {:?}", outcome.transaction);
+            }
+            Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
+                outcome_receipt,
+            )) => {
+                println!("Final Exuecution outcome_reciepts: {:?}", outcome_receipt)
+            }
+            None => println!("No Final execution outcome."),
+        },
+        Err(err) => println!("Error: {:#?}", err),
+    }
 
     //Check the status of the transaction now.
     let transaction_info = TransactionInfo::TransactionId {
@@ -83,8 +81,5 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     println!("Time taken for aysnc request: {:?}",t2-t1);
     println!("Time taken for status request: {:?}",t4-t3);
-
-    println!("Time taken for two requests: {:?}",(t4-t3)+(t2-t1));
-
     Ok(())
 }

--- a/near-accounts/examples/create_account.rs
+++ b/near-accounts/examples/create_account.rs
@@ -1,6 +1,6 @@
 use near_accounts::Account;
 use near_crypto::InMemorySigner;
-use near_primitives::types::Gas;
+use near_primitives::{types::Gas, views::FinalExecutionOutcomeViewEnum};
 use near_providers::JsonRpcProvider;
 use std::sync::Arc;
 mod utils;
@@ -43,11 +43,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await;
 
     match result {
-        Ok(res) => {
-            println!("transaction: {:#?}", res.transaction);
-            println!("status: {:#?}", res.status);
-            println!("receipts_outcome {:#?}", res.transaction_outcome);
-        }
+        Ok(res) => match &res.final_execution_outcome {
+            Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(outcome)) => {
+                println!("Final Exuecution outcome: {:?}", outcome);
+                println!("Final Exuecution outcome: {:?}", outcome.transaction);
+            }
+            Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
+                outcome_receipt,
+            )) => {
+                println!("Final Exuecution outcome: {:?}", outcome_receipt)
+            }
+            None => println!("No Final execution outcome."),
+        },
         Err(err) => println!("Error: {:#?}", err),
     }
 

--- a/near-accounts/examples/create_account.rs
+++ b/near-accounts/examples/create_account.rs
@@ -38,6 +38,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = account
         .function_call(&contract_id, method_name, args_json, gas, amount)
+        .await?
+        .transact()
         .await;
 
     match result {

--- a/near-accounts/examples/function_call.rs
+++ b/near-accounts/examples/function_call.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 mod utils;
 use near_primitives::types::AccountId;
 use serde_json::json;
-use tokio::time;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -28,15 +27,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args_json = json!({"message": "working1"});
 
-    let t1 = time::Instant::now();
     let result = account
         .function_call(&contract_id, method_name, args_json, gas, 0)
         .await?
         .transact()
         .await;
-    let t2 = time::Instant::now();
     println!("response: {:#?}", result);
-    println!("Time taken: {:?}",t2-t1);
 
     Ok(())
 }

--- a/near-accounts/examples/function_call.rs
+++ b/near-accounts/examples/function_call.rs
@@ -1,22 +1,23 @@
 use near_accounts::Account;
 use near_crypto::InMemorySigner;
+use near_crypto::SecretKey;
 use near_primitives::types::Gas;
 use near_providers::JsonRpcProvider;
 use std::sync::Arc;
 mod utils;
 use near_primitives::types::AccountId;
 use serde_json::json;
+use tokio::time;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    let signer_account_id: AccountId = utils::input("Enter the signer Account ID: ")?.parse()?;
-    let signer_secret_key = utils::input("Enter the signer's private key: ")?.parse()?;
+    let signer_account_id: AccountId = "near-api-rs.testnet".parse::<AccountId>()?;
+    let signer_secret_key = "ed25519:29nYmQCZMsQeYtztXZzm57ayQt2uBHXdn2SAjK4ccMGSQaNUFNJ7Aoteno81eKTex9cGBbk1FuDuqJRsdzx34xDY".parse::<SecretKey>()?;
     let contract_id: AccountId = "contract.near-api-rs.testnet".parse::<AccountId>()?;
     let signer = InMemorySigner::from_secret_key(signer_account_id.clone(), signer_secret_key);
 
-    // Amount to transfer to the new account
     let gas: Gas = 100_000_000_000_000; // Example amount in yoctoNEAR
 
     let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
@@ -27,13 +28,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args_json = json!({"message": "working1"});
 
+    let t1 = time::Instant::now();
     let result = account
         .function_call(&contract_id, method_name, args_json, gas, 0)
         .await?
         .transact()
         .await;
-
+    let t2 = time::Instant::now();
     println!("response: {:#?}", result);
+    println!("Time taken: {:?}",t2-t1);
 
     Ok(())
 }

--- a/near-accounts/examples/function_call.rs
+++ b/near-accounts/examples/function_call.rs
@@ -29,6 +29,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = account
         .function_call(&contract_id, method_name, args_json, gas, 0)
+        .await?
+        .transact()
         .await;
 
     println!("response: {:#?}", result);

--- a/near-accounts/examples/view_function.rs
+++ b/near-accounts/examples/view_function.rs
@@ -1,5 +1,4 @@
-use near_accounts::Account;
-use near_crypto::InMemorySigner;
+use near_accounts::accounts::view_function;
 use near_providers::JsonRpcProvider;
 use std::sync::Arc;
 mod utils;
@@ -10,20 +9,14 @@ use serde_json::json;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    let signer_account_id: AccountId = utils::input("Enter the signer Account ID: ")?.parse()?;
-    let signer_secret_key = utils::input("Enter the signer's private key: ")?.parse()?;
     let contract_id: AccountId = "contract.near-api-rs.testnet".parse::<AccountId>()?;
-    let signer = InMemorySigner::from_secret_key(signer_account_id.clone(), signer_secret_key);
 
     let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
-    let signer = Arc::new(signer);
 
-    let account = Account::new(signer_account_id, signer, provider);
     let args_json = json!({"account_id": "contract.near-api-rs.testnet"});
     let method_name = "get_status".to_string();
 
-    let result = account
-        .view_function(contract_id, method_name, args_json)
+    let result = view_function(provider, contract_id, method_name, args_json)
         .await;
 
     println!("response: {:#?}", result);

--- a/near-accounts/examples/view_function.rs
+++ b/near-accounts/examples/view_function.rs
@@ -16,8 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args_json = json!({"account_id": "contract.near-api-rs.testnet"});
     let method_name = "get_status".to_string();
 
-    let result = view_function(provider, contract_id, method_name, args_json)
-        .await;
+    let result = view_function(provider, contract_id, method_name, args_json).await;
 
     println!("response: {:#?}", result);
 

--- a/near-accounts/src/accounts.rs
+++ b/near-accounts/src/accounts.rs
@@ -410,7 +410,46 @@ impl Account {
         Ok(TransactionSender::new(signed_tx, self.provider.clone()))
     }
 
-    /// Calls a view function on a contract deployed on the NEAR blockchain.
+    // /// Calls a view function on a contract deployed on the NEAR blockchain.
+    // ///
+    // /// View functions are read-only and do not modify state. They're free to call.
+    // ///
+    // /// # Arguments
+    // ///
+    // /// * `contract_id` - The account ID of the contract.
+    // /// * `method_name` - The name of the view function to call.
+    // /// * `args` - The arguments to the function call, typically in the form of a serialized byte array (`FunctionArgs`).
+    // ///
+    // /// # Returns
+    // ///
+    // /// A `Result` containing the result of the function call or an error if the operation fails.
+    // pub async fn view_function(
+    //     &self,
+    //     contract_id: AccountId,
+    //     method_name: String,
+    //     args: Value,
+    // ) -> Result<near_primitives::views::CallResult, Box<dyn std::error::Error>> {
+    //     let args_vec = serde_json::to_vec(&args)?.into();
+
+    //     let query_request = QueryRequest::CallFunction {
+    //         account_id: contract_id.clone(),
+    //         method_name: method_name.clone(),
+    //         args: args_vec,
+    //     };
+
+    //     // Send the query to the NEAR blockchain
+    //     let response: RpcQueryResponse = self.provider.query(query_request).await?;
+
+    //     if let QueryResponseKind::CallResult(result) = response.kind {
+    //         Ok(result)
+    //     } else {
+    //         Err("Unexpected response kind".into())
+    //     }
+    // }
+}
+
+
+/// Calls a view function on a contract deployed on the NEAR blockchain.
     ///
     /// View functions are read-only and do not modify state. They're free to call.
     ///
@@ -424,7 +463,7 @@ impl Account {
     ///
     /// A `Result` containing the result of the function call or an error if the operation fails.
     pub async fn view_function(
-        &self,
+        provider: Arc<dyn Provider>,
         contract_id: AccountId,
         method_name: String,
         args: Value,
@@ -438,7 +477,7 @@ impl Account {
         };
 
         // Send the query to the NEAR blockchain
-        let response: RpcQueryResponse = self.provider.query(query_request).await?;
+        let response: RpcQueryResponse = provider.query(query_request).await?;
 
         if let QueryResponseKind::CallResult(result) = response.kind {
             Ok(result)
@@ -446,7 +485,6 @@ impl Account {
             Err("Unexpected response kind".into())
         }
     }
-}
 
 /// Queries the state of a contract on the NEAR blockchain using a key prefix.
 ///

--- a/near-api-lib/examples/create_account.rs
+++ b/near-api-lib/examples/create_account.rs
@@ -39,6 +39,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = account
         .function_call(&contract_id, method_name, args_json, gas, amount)
+        .await?
+        .transact()
         .await;
 
     println!("response: {:#?}", result);

--- a/near-providers/Cargo.toml
+++ b/near-providers/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["full"] }
 async-trait = "0.1.50"
 serde_json = "1.0.85"
 
-near-jsonrpc-client = {git = 'https://github.com/near/near-jsonrpc-client-rs'}
+near-jsonrpc-client = "0.9.0"
 near-crypto = "0.21.1"
 near-primitives = "0.21.1"
 near-chain-configs = "0.21.1"

--- a/near-providers/src/json_rpc_provider.rs
+++ b/near-providers/src/json_rpc_provider.rs
@@ -84,6 +84,19 @@ impl Provider for JsonRpcProvider {
         self.client.call(request).await
     }
 
+    /// Sends a signed transaction to the NEAR blockchain. With additional parameter wait_until to define transaction finality.
+    async fn send_tx(
+        &self,
+        signed_transaction: SignedTransaction,
+        wait_until: TxExecutionStatus,
+    ) -> Result<RpcTransactionResponse, JsonRpcError<RpcTransactionError>> {
+        let request = methods::send_tx::RpcSendTransactionRequest {
+            signed_transaction: signed_transaction,
+            wait_until: wait_until.clone(),
+        };
+        self.client.call(request).await
+    }
+
     /// Retrieves the status of a transaction on the NEAR blockchain, identified by `TransactionInfo`.
     async fn tx_status(
         &self,

--- a/near-providers/src/json_rpc_provider.rs
+++ b/near-providers/src/json_rpc_provider.rs
@@ -91,7 +91,7 @@ impl Provider for JsonRpcProvider {
         wait_until: TxExecutionStatus,
     ) -> Result<RpcTransactionResponse, JsonRpcError<RpcTransactionError>> {
         let request = methods::send_tx::RpcSendTransactionRequest {
-            signed_transaction: signed_transaction,
+            signed_transaction,
             wait_until: wait_until.clone(),
         };
         self.client.call(request).await

--- a/near-providers/src/provider.rs
+++ b/near-providers/src/provider.rs
@@ -37,16 +37,26 @@ pub trait Provider {
     async fn status(&self) -> Result<RpcStatusResponse, JsonRpcError<RpcStatusError>>;
 
     /// Sends a transaction to the NEAR blockchain, waiting for its final execution outcome.
+    /// This RPC is deprecated by NEAR. Could be removed anytime from the RPC server.
     async fn send_transaction(
         &self,
         signed_transaction: SignedTransaction,
     ) -> Result<FinalExecutionOutcomeView, JsonRpcError<RpcTransactionError>>;
 
     /// Sends a transaction to the NEAR blockchain asynchronously, without waiting for its final execution outcome.
+    /// This RPC is deprecated by NEAR. Could be removed anytime from the RPC server.
     async fn send_transaction_async(
         &self,
         signed_transaction: SignedTransaction,
     ) -> Result<CryptoHash, JsonRpcError<methods::broadcast_tx_async::RpcBroadcastTxAsyncError>>;
+
+    /// New RPC method introduced for sending transactions. With new parameter wait_until for transaction finality.
+    /// TO-do Write about different value of wait_until
+    async fn send_tx(
+        &self,
+        signed_transaction: SignedTransaction,
+        wait_until: TxExecutionStatus,
+    ) -> Result<RpcTransactionResponse, JsonRpcError<RpcTransactionError>>;
 
     /// Fetches the status of a specific transaction, given its information.
     async fn tx_status(


### PR DESCRIPTION
- Introduced send_tx rpc api
- Updated send_transaction in near-accounts to use the new api
- Separate transaction creation + signing and sending for function_call
- Introduced transact(), transact_async(), transact_advanced() to enable different transaction sending functions